### PR TITLE
Add support for ASCII armor

### DIFF
--- a/age/age.cabal
+++ b/age/age.cabal
@@ -104,7 +104,8 @@ test-suite age-test
                        -Wunused-packages
                        -Wno-unticked-promoted-constructors
 
-  other-modules:       Test.Crypto.Age.Conduit
+  other-modules:       Test.Crypto.Age.Armor
+                       Test.Crypto.Age.Conduit
                        Test.Crypto.Age.Header
                        Test.Crypto.Age.Header.Gen
                        Test.Crypto.Age.Identity

--- a/age/age.cabal
+++ b/age/age.cabal
@@ -64,6 +64,7 @@ library
                        Data.Binary.Put.Integer
                        Data.ByteString.Base64.Extra
                        Data.ByteString.Extra
+                       Data.Conduit.Base64
 
   build-depends:       base >= 4.17 && < 5
                      , attoparsec

--- a/age/age.cabal
+++ b/age/age.cabal
@@ -47,6 +47,7 @@ library
                        -Wno-unticked-promoted-constructors
 
   exposed-modules:     Crypto.Age
+                       Crypto.Age.Armor
                        Crypto.Age.Buffered
                        Crypto.Age.Conduit
                        Crypto.Age.Header
@@ -60,7 +61,8 @@ library
                        Crypto.Age.Recipient.Stanza
                        Crypto.Age.Scrypt
 
-  other-modules:       Data.Attoparsec.ByteString.Extra
+  other-modules:       Data.Attoparsec.ByteString.Base64
+                       Data.Attoparsec.ByteString.Extra
                        Data.Binary.Put.Integer
                        Data.ByteString.Base64.Extra
                        Data.ByteString.Extra
@@ -134,6 +136,7 @@ test-suite age-test
                      , hedgehog
                      , memory
                      , mmorph
+                     , mtl
                      , text
 
 source-repository head

--- a/age/src/Crypto/Age.hs
+++ b/age/src/Crypto/Age.hs
@@ -22,6 +22,14 @@ module Crypto.Age
     -- ** Errors
   , DecryptError (..)
 
+    -- * ASCII armor
+    -- ** Encoding
+  , ArmorError (..)
+  , conduitArmor
+    -- ** Decoding
+  , UnarmorError (..)
+  , conduitUnarmor
+
     -- * Identity
   , Identity (..)
     -- ** @scrypt@
@@ -51,6 +59,8 @@ module Crypto.Age
   , DecodeX25519RecipientError (..)
   ) where
 
+import Crypto.Age.Armor
+  ( ArmorError (..), UnarmorError (..), conduitArmor, conduitUnarmor )
 import Crypto.Age.Buffered ( decrypt, decryptLazy, encrypt, encryptLazy )
 import Crypto.Age.Conduit
   ( DecryptError (..)

--- a/age/src/Crypto/Age/Armor.hs
+++ b/age/src/Crypto/Age/Armor.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | age
+-- [ASCII armor](https://github.com/C2SP/C2SP/blob/03ab74455beb3a6d6e0fb7dd1de5a932e2257cd0/age.md#ascii-armor)
+-- encoding and decoding.
+module Crypto.Age.Armor
+  ( -- * Decoding
+    UnarmorError (..)
+  , conduitUnarmor
+  ) where
+
+import Control.Applicative ( Alternative (..), optional )
+import Control.Monad ( void )
+import Control.Monad.Except ( ExceptT, throwError, withExceptT )
+import Control.Monad.Trans.Class ( MonadTrans (lift) )
+import Data.Attoparsec.ByteString ( Parser, count, endOfInput, string )
+import Data.Attoparsec.ByteString.Base64 ( takeNBase64Chars )
+import Data.Attoparsec.ByteString.Char8 ( char8, endOfLine, skipSpace )
+import Data.Attoparsec.ByteString.Extra ( countMN )
+import Data.ByteString ( ByteString )
+import qualified Data.ByteString as BS
+import Data.Conduit ( ConduitT, await, leftover, transPipe, yield, (.|) )
+import Data.Conduit.Attoparsec ( ParseError, sinkParserEither )
+import Data.Conduit.Base64 ( conduitDecodeBase64 )
+import Data.Text ( Text )
+import Data.Word ( Word8 )
+import Prelude
+
+label :: ByteString
+label = "AGE ENCRYPTED FILE"
+
+lineBegin :: ByteString
+lineBegin = "-----BEGIN " <> label <> "-----"
+
+lineEnd :: ByteString
+lineEnd = "-----END " <> label <> "-----"
+
+-------------------------------------------------------------------------------
+-- Decoding
+-------------------------------------------------------------------------------
+
+-- | @eol@ rule from
+-- [RFC 7468](https://www.rfc-editor.org/rfc/rfc7468.html#section-3).
+eolParser :: Parser ()
+eolParser = endOfLine <|> void (char8 '\r')
+
+lineBeginParser :: Parser ()
+lineBeginParser = do
+  void $ string lineBegin
+  eolParser
+
+lineEndParser :: Parser ()
+lineEndParser = void $ string lineEnd
+
+-- | @4base64char@ rule from
+-- [RFC 7468](https://www.rfc-editor.org/rfc/rfc7468.html#section-3).
+fourBase64CharParser :: Parser ByteString
+fourBase64CharParser = takeNBase64Chars 4
+
+-- | @base64pad@ rule from
+-- [RFC 7468](https://www.rfc-editor.org/rfc/rfc7468.html#section-3).
+base64PadParser :: Parser Word8
+base64PadParser = char8 '='
+
+-- | Parsed base64-encoded line.
+data Base64Line
+  = -- | Unpadded base64-encoded line of 64 characters.
+    Base64FullUnpaddedLine !ByteString
+  | -- | Padded base64-encoded line of 64 characters.
+    Base64FullPaddedLine !ByteString
+  | -- | Base64-encoded line (either padded or unpadded) of less than 64
+    -- characters.
+    Base64ShortLine !ByteString
+
+-- | @base64fullline@ rule from
+-- [RFC 7468](https://www.rfc-editor.org/rfc/rfc7468.html#section-3).
+base64FullUnpaddedLineParser :: Parser Base64Line
+base64FullUnpaddedLineParser = Base64FullUnpaddedLine <$> (takeNBase64Chars 64 <* eolParser)
+
+-- | Variant of the @strictbase64finl@ rule from
+-- [RFC 7468](https://www.rfc-editor.org/rfc/rfc7468.html#section-3) which only
+-- parses a base64-encoded and padded line of 64 characters.
+base64FullPaddedLineParser :: Parser Base64Line
+base64FullPaddedLineParser =  do
+  b64Chars <- count 15 fourBase64CharParser
+  remainingB64Chars <- remainingB64CharsParser
+  eolParser
+  pure $ Base64FullPaddedLine (BS.concat b64Chars <> remainingB64Chars)
+  where
+    remainingB64CharsParser :: Parser ByteString
+    remainingB64CharsParser =
+      (mappend <$> takeNBase64Chars 3 <*> (BS.singleton <$> base64PadParser))
+        <|> (mappend <$> takeNBase64Chars 2 <*> (BS.pack <$> count 2 base64PadParser))
+
+-- | Variant of the @strictbase64finl@ rule from
+-- [RFC 7468](https://www.rfc-editor.org/rfc/rfc7468.html#section-3) which only
+-- parses a base64-encoded line (either padded or not) that is less than 64
+-- characters.
+base64ShortLineParser :: Parser Base64Line
+base64ShortLineParser = do
+  b64Chars <- countMN 0 14 fourBase64CharParser
+  remainingB64Chars <-
+    if length b64Chars == 0
+      then Just <$> remainingB64CharsParser
+      else optional remainingB64CharsParser
+  eolParser
+  pure $ Base64ShortLine (BS.concat b64Chars <> maybe BS.empty id remainingB64Chars)
+  where
+    remainingB64CharsParser :: Parser ByteString
+    remainingB64CharsParser =
+      takeNBase64Chars 4
+        <|> (mappend <$> takeNBase64Chars 3 <*> (BS.singleton <$> base64PadParser))
+        <|> (mappend <$> takeNBase64Chars 2 <*> (BS.pack <$> count 2 base64PadParser))
+
+sinkParseLineBegin :: Monad m => ConduitT ByteString o m (Either ParseError ())
+sinkParseLineBegin = sinkParserEither lineBeginParser
+
+-- | Internal helper type for 'conduitParseBase64UntilLineEnd'.
+data ParsedLine
+  = ParsedLineBase64 !Base64Line
+  | ParsedLineEnd
+
+conduitParseBase64UntilLineEnd :: Monad m => ConduitT ByteString ByteString (ExceptT UnarmorError m) ()
+conduitParseBase64UntilLineEnd = await >>= \case
+  Nothing ->
+    -- End of input was reached, but the ending line was not parsed.
+    lift (throwError UnarmorNoLineEndError)
+  Just x -> do
+    leftover x
+    res <-
+      sinkParserEither $
+        (ParsedLineBase64 <$> base64FullUnpaddedLineParser)
+          <|> (ParsedLineBase64 <$> base64FullPaddedLineParser)
+          <|> (ParsedLineBase64 <$> base64ShortLineParser)
+          <|> (lineEndIgnoreWhitespaceParser *> pure ParsedLineEnd)
+    case res of
+      Left err -> lift (throwError $ UnarmorParseError err)
+      Right (ParsedLineBase64 parsedB64Line) ->
+        case parsedB64Line of
+          Base64FullUnpaddedLine b64Line -> do
+            yield b64Line
+            conduitParseBase64UntilLineEnd
+          Base64FullPaddedLine b64Line -> do
+            -- Parsed a padded line, so we should be at the end line now.
+            yield b64Line
+            lineEndRes <- sinkParserEither lineEndIgnoreWhitespaceParser
+            case lineEndRes of
+              Left err -> lift (throwError $ UnarmorParseError err)
+              Right () -> pure ()
+          Base64ShortLine b64Line -> do
+            -- Parsed a short line, so we should be at the end line now.
+            yield b64Line
+            lineEndRes <- sinkParserEither lineEndIgnoreWhitespaceParser
+            case lineEndRes of
+              Left err -> lift (throwError $ UnarmorParseError err)
+              Right () -> pure ()
+      Right ParsedLineEnd -> pure ()
+  where
+    lineEndIgnoreWhitespaceParser :: Parser ()
+    lineEndIgnoreWhitespaceParser = lineEndParser >> skipSpace >> endOfInput
+
+-- | Error
+-- \"un-[armoring](https://github.com/C2SP/C2SP/blob/03ab74455beb3a6d6e0fb7dd1de5a932e2257cd0/age.md#ascii-armor)\"
+-- an age file.
+data UnarmorError
+  = -- | End of input was reached immediately after parsing the beginning line.
+    UnarmorNoDataAfterLineBeginError
+  | -- | End of input was reached before the ending line was parsed.
+    UnarmorNoLineEndError
+  | -- | Error parsing the ASCII-armored age file.
+    UnarmorParseError !ParseError
+  | -- | Error base64 decoding the encapsulated text portion of the
+    -- ASCII-armored age file.
+    UnarmorDecodeBase64Error !Text
+  deriving stock (Show)
+
+-- | Stream and
+-- \"un-[armor](https://github.com/C2SP/C2SP/blob/03ab74455beb3a6d6e0fb7dd1de5a932e2257cd0/age.md#ascii-armor)\"
+-- an age file.
+conduitUnarmor :: Monad m => ConduitT ByteString ByteString (ExceptT UnarmorError m) ()
+conduitUnarmor = do
+  -- Ignore leading whitespace
+  void (sinkParserEither skipSpace)
+
+  sinkParseLineBegin >>= \case
+    Left err -> lift (throwError $ UnarmorParseError err)
+    Right () -> pure ()
+
+  -- Ensure that we try to parse at least one more line.
+  await >>= \case
+    Nothing -> lift (throwError UnarmorNoDataAfterLineBeginError)
+    Just x -> do
+      leftover x
+      conduitParseBase64UntilLineEnd
+        .| transPipe (withExceptT UnarmorDecodeBase64Error) conduitDecodeBase64

--- a/age/src/Crypto/Age/Header.hs
+++ b/age/src/Crypto/Age/Header.hs
@@ -21,20 +21,9 @@ import qualified Crypto.Hash as Crypto
 import qualified Crypto.KDF.HKDF as HKDF
 import qualified Crypto.MAC.HMAC as Crypto
 import Data.Attoparsec.ByteString
-  ( Parser
-  , count
-  , inClass
-  , many'
-  , many1'
-  , satisfy
-  , sepBy1'
-  , string
-  , take
-  , takeWhile1
-  , (<?>)
-  )
+  ( Parser, many', many1', sepBy1', string, take, takeWhile1 )
+import Data.Attoparsec.ByteString.Base64 ( takeMNBase64Chars, takeNBase64Chars )
 import Data.Attoparsec.ByteString.Char8 ( char8 )
-import Data.Attoparsec.ByteString.Extra ( takeWhileMN )
 import Data.ByteArray ( ScrubbedBytes, constEq )
 import qualified Data.ByteArray as BA
 import Data.ByteString ( ByteString )
@@ -49,30 +38,7 @@ import qualified Data.List as L
 import Data.List.NonEmpty ( NonEmpty )
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
-import Data.Word ( Word8 )
 import Prelude hiding ( take )
-
--- | Determine whether a 'Word8' is a valid character in an unpadded base64
--- string.
-isBase64Char :: Word8 -> Bool
-isBase64Char = inClass "a-zA-Z0-9+/"
-
--- | Parse a base64 character.
-base64CharParser :: Parser Word8
-base64CharParser = satisfy isBase64Char <?> "base64 character"
-
--- | Consume exactly @n@ base64 characters.
-takeNBase64Chars :: Word -> Parser ByteString
-takeNBase64Chars n = BS.pack <$> count (fromIntegral n) base64CharParser
-
--- | Consume a base64 character string of length @m <= len <= n@.
-takeMNBase64Chars ::
-  -- | @m@.
-  Word ->
-  -- | @n@.
-  Word ->
-  Parser ByteString
-takeMNBase64Chars m n = takeWhileMN m n isBase64Char
 
 -- | Parse an ABNF @VCHAR@ string as specified in
 -- [RFC 2234 section 6.1](https://www.rfc-editor.org/rfc/rfc2234#section-6.1).

--- a/age/src/Data/Attoparsec/ByteString/Base64.hs
+++ b/age/src/Data/Attoparsec/ByteString/Base64.hs
@@ -1,0 +1,35 @@
+module Data.Attoparsec.ByteString.Base64
+  ( isBase64Char
+  , base64CharParser
+  , takeNBase64Chars
+  , takeMNBase64Chars
+  ) where
+
+import Data.Attoparsec.ByteString ( Parser, count, inClass, satisfy, (<?>) )
+import Data.Attoparsec.ByteString.Extra ( takeWhileMN )
+import Data.ByteString ( ByteString )
+import qualified Data.ByteString as BS
+import Data.Word ( Word8 )
+import Prelude
+
+-- | Determine whether a 'Word8' is a valid character in an unpadded base64
+-- string.
+isBase64Char :: Word8 -> Bool
+isBase64Char = inClass "a-zA-Z0-9+/"
+
+-- | Parse a base64 character.
+base64CharParser :: Parser Word8
+base64CharParser = satisfy isBase64Char <?> "base64 character"
+
+-- | Consume exactly @n@ base64 characters.
+takeNBase64Chars :: Word -> Parser ByteString
+takeNBase64Chars n = BS.pack <$> count (fromIntegral n) base64CharParser
+
+-- | Consume a base64 character string of length @m <= len <= n@.
+takeMNBase64Chars ::
+  -- | @m@.
+  Word ->
+  -- | @n@.
+  Word ->
+  Parser ByteString
+takeMNBase64Chars m n = takeWhileMN m n isBase64Char

--- a/age/src/Data/Conduit/Base64.hs
+++ b/age/src/Data/Conduit/Base64.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE CPP #-}
+
+module Data.Conduit.Base64
+  ( conduitEncodeBase64
+  , conduitDecodeBase64
+  ) where
+
+import Control.Exception ( assert )
+import Control.Monad.Except ( ExceptT, throwError )
+import Control.Monad.Trans.Class ( MonadTrans (lift) )
+import Data.Text ( Text )
+#if MIN_VERSION_base64(1,0,0)
+import qualified Data.Base64.Types as B64
+#endif
+import Data.ByteString ( ByteString )
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as B64
+import Data.Conduit ( ConduitT, await, yield )
+import Data.MonoTraversable ( olength )
+import Prelude
+
+conduitEncodeBase64 :: Monad m => ConduitT ByteString ByteString m ()
+conduitEncodeBase64 =
+  codeWith 3
+#if MIN_VERSION_base64(1,0,0)
+    (Right . B64.extractBase64 . B64.encodeBase64')
+#else
+    (Right . B64.encodeBase64')
+#endif
+    (error "conduitEncodeBase64: impossible: base64 encoding cannot fail")
+
+conduitDecodeBase64 :: Monad m => ConduitT ByteString ByteString (ExceptT Text m) ()
+conduitDecodeBase64 =
+  codeWith 4
+#if MIN_VERSION_base64(1,0,0)
+    B64.decodeBase64Untyped
+#else
+    B64.decodeBase64
+#endif
+    (lift . throwError)
+
+codeWith ::
+  Monad m =>
+  Int ->
+  -- | Encoding or decoding function.
+  (ByteString -> Either e ByteString) ->
+  -- | Error handling function.
+  (e -> ConduitT ByteString ByteString m ()) ->
+  ConduitT ByteString ByteString m ()
+codeWith size f handleErr =
+    loop
+  where
+    loop = await >>= maybe (return ()) push
+
+    loopWith bs
+        | BS.null bs = loop
+        | otherwise = await >>= maybe (finish bs) (pushWith bs)
+
+    finish bs =
+        case f bs of
+            Left err -> handleErr err
+            Right x -> yield x
+
+    push bs = do
+        let (x, y) = BS.splitAt (len - (len `mod` size)) bs
+        if BS.null x
+            then loopWith y
+            else do
+                case f x of
+                    Left err -> handleErr err
+                    Right x' -> yield x' >> loopWith y
+      where
+        len = olength bs
+
+    pushWith bs1 bs2 | BS.length bs1 + BS.length bs2 < size = loopWith (BS.append bs1 bs2)
+    pushWith bs1 bs2 = assertion1 $ assertion2 $ assertion3 $
+        case f bs1' of
+            Left err -> handleErr err
+            Right toYield -> yield toYield >> push y
+      where
+        m = BS.length bs1 `mod` size
+        (x, y) = BS.splitAt (size - m) bs2
+        bs1' = mappend bs1 x
+
+        assertion1 = assert $ olength bs1 < size
+        assertion2 = assert $ olength bs1' `mod` size == 0
+        assertion3 = assert $ olength bs1' > 0

--- a/age/test/Main.hs
+++ b/age/test/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Hedgehog.Main ( defaultMain )
 import Prelude
+import qualified Test.Crypto.Age.Armor
 import qualified Test.Crypto.Age.Conduit
 import qualified Test.Crypto.Age.Header
 import qualified Test.Crypto.Age.Identity
@@ -13,7 +14,8 @@ import qualified Test.Crypto.Age.TestVector
 main :: IO ()
 main =
   defaultMain
-    [ Test.Crypto.Age.Conduit.tests
+    [ Test.Crypto.Age.Armor.tests
+    , Test.Crypto.Age.Conduit.tests
     , Test.Crypto.Age.Header.tests
     , Test.Crypto.Age.Identity.tests
     , Test.Crypto.Age.Key.tests

--- a/age/test/Test/Crypto/Age/Armor.hs
+++ b/age/test/Test/Crypto/Age/Armor.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Crypto.Age.Armor
+  ( tests
+  ) where
+
+import Control.Monad.Except ( runExceptT )
+import Crypto.Age.Armor ( ArmorError (..), conduitArmor, conduitUnarmor )
+import qualified Data.Conduit as C
+import qualified Data.Conduit.Combinators as C
+import qualified Data.Conduit.List as CL
+import Data.Functor.Identity ( runIdentity )
+import Hedgehog
+  ( Property
+  , annotateShow
+  , checkParallel
+  , discover
+  , forAll
+  , property
+  , withTests
+  , (===)
+  )
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Prelude
+
+tests :: IO Bool
+tests = checkParallel $$(discover)
+
+------------------------------------------------------------------------------
+-- Properties
+------------------------------------------------------------------------------
+
+-- | Test that 'conduitArmor' and 'conduitUnarmor' round trip.
+prop_roundTrip_conduitArmorUnarmor :: Property
+prop_roundTrip_conduitArmorUnarmor = property $ do
+  expected <- forAll $ Gen.bytes (Range.linear 1 1024)
+  let sourceExpected = C.yield expected
+
+  let encodedRes =
+        runIdentity . runExceptT . C.runConduit $
+          sourceExpected
+            C..| conduitArmor
+            C..| C.fold
+  annotateShow encodedRes
+  encoded <-
+    case encodedRes of
+      Left err -> fail $ "failed to armor: " <> show err
+      Right x -> pure x
+
+  let actualRes =
+        runIdentity . runExceptT . C.runConduit $
+          C.yield encoded
+            C..| conduitUnarmor
+            C..| C.fold
+  actual <-
+    case actualRes of
+      Left err -> fail $ "failed to unarmor: " <> show err
+      Right x -> pure x
+
+  expected === actual
+
+-- | Test that 'conduitArmor' fails when no data is pushed from upstream.
+prop_conduitArmorFailsWithNullSource :: Property
+prop_conduitArmorFailsWithNullSource = withTests 1 . property $ do
+  let res =
+        runIdentity . runExceptT . C.runConduit $
+          CL.sourceNull
+            C..| conduitArmor
+            C..| C.fold
+  case res of
+    Left ArmorNoDataError -> pure ()
+    Right _ -> fail $ "expected " <> show ArmorNoDataError <> " but got a success result"
+
+-- | Test that 'conduitArmor' fails when only an empty 'ByteString' is pushed
+-- from upstream.
+prop_conduitArmorFailsWithEmptyByteString :: Property
+prop_conduitArmorFailsWithEmptyByteString = withTests 1 . property $ do
+  let res =
+        runIdentity . runExceptT . C.runConduit $
+          C.yield ""
+            C..| conduitArmor
+            C..| C.fold
+  case res of
+    Left ArmorNoDataError -> pure ()
+    Right _ -> fail $ "expected " <> show ArmorNoDataError <> " but got a success result"


### PR DESCRIPTION
Add support for encoding and decoding [ASCII-armored](https://github.com/C2SP/C2SP/blob/36b7b706894bbeaa8984b2a86b4143f65f1ff913/age.md#ascii-armor) age files.